### PR TITLE
Updated cloudwatch namespace to use System/Linux

### DIFF
--- a/aws-mon.sh
+++ b/aws-mon.sh
@@ -317,7 +317,7 @@ if [ $FROM_CRON -eq 1 ]; then
 fi
 
 # CloudWatch Command Line Interface Option
-CLOUDWATCH_OPTS="--namespace System/Detail/Linux --dimensions InstanceId=$instanceid"
+CLOUDWATCH_OPTS="--namespace System/Linux --dimensions InstanceId=$instanceid"
 if [ -n "$PROFILE" ]; then
     CLOUDWATCH_OPTS="$CLOUDWATCH_OPTS --profile $PROFILE"
 fi


### PR DESCRIPTION
System/Linux is a cloudwatch provided namespace, using System/Details/Linux causes the metrics to be listed under "Custom metrics" which seems unnecessary
