### PR TITLE
Default to exclude cache & buffers from mem used

### DIFF
--- a/aws-mon.sh
+++ b/aws-mon.sh
@@ -450,7 +450,7 @@ mem_cached=`expr $mem_cached \* $KILO`
 mem_buffers=`getMemInfo "Buffers"`
 mem_buffers=`expr $mem_buffers \* $KILO`
 mem_avail=$mem_free
-if [ $MEM_USED_INCL_CACHE_BUFF -eq 1 ]; then
+if [ $MEM_USED_INCL_CACHE_BUFF -eq 0 ]; then
     mem_avail=`expr $mem_avail + $mem_cached + $mem_buffers`
 fi
 mem_used=`expr $mem_total - $mem_avail`


### PR DESCRIPTION
I found the same issue as in #6, however this solution aligns closer to the current implementation in the [Amazon CloudWatch Monitoring Scripts](https://aws.amazon.com/code/8720044071969977) which uses:

``` perl
  if (!defined($mem_used_incl_cache_buff)) {
     $mem_avail += $mem_cached + $mem_buffers;
  }
```
